### PR TITLE
update noble -> agoric connection info for ICA host

### DIFF
--- a/_IBC/agoric-noble.json
+++ b/_IBC/agoric-noble.json
@@ -8,7 +8,7 @@
   "chain_2": {
     "chain_name": "noble",
     "client_id": "07-tendermint-32",
-    "connection_id": "connection-40"
+    "connection_id": "connection-38"
   },
   "channels": [
     {


### PR DESCRIPTION
We discovered a discrepancy between this file and map of zones. This query also points out that the right connection_id is connection-38:

```console
$ agd query ibc connection end connection-72 --node https://agoric-rpc.polkachu.com:443
connection:
  client_id: 07-tendermint-77
  counterparty:
    client_id: 07-tendermint-32
    connection_id: connection-38
```

cc @0xpatrickdev @turadg 